### PR TITLE
fix: Date parsing when timestamp has no decimals

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -131,12 +131,12 @@ it('parse date parameter', () => {
     });
     const event = {
         ...basePrismaQueryEvent,
-        query: 'INSERT INTO Comment (commentId, createdAt) VALUES (?,?)',
-        params: '["1",2020-12-25 19:35:06.803149100 UTC]',
+        query: 'INSERT INTO Comment (commentId, createdAt, updatedAt) VALUES (?,?,?)',
+        params: '["1",2020-12-25 19:35:06.803149100 UTC, 2021-10-01 00:00:00 UTC]',
     };
     log(event);
     expect(query).toEqual(
-        'INSERT INTO Comment (commentId, createdAt) VALUES ("1", "2020-12-25 19:35:06.803149100 UTC")',
+        'INSERT INTO Comment (commentId, createdAt, updatedAt) VALUES ("1", "2020-12-25 19:35:06.803149100 UTC", "2021-10-01 00:00:00 UTC")',
     );
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export function createPrismaQueryEventHandler(
 
     return function prismaQueryLog(event: PrismaQueryEvent) {
         const eventParams = event.params.replace(
-            /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ UTC/g,
+            /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.?\d* UTC/g,
             date => `"${date}"`,
         );
         // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment


### PR DESCRIPTION
When timestamp has no decimals