### PR TITLE
feat: Added event duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ const defaultOptions = {
      */
 
     /**
+     * Show Query Duration, default is false
+     */
+    queryDuration: false as boolean,
+
+    /**
      * Query language, default is Standard SQL
      */
     language: undefined as 'sql' | 'n1ql' | 'db2' | 'pl/sql' | undefined,

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -351,3 +351,23 @@ it('backticked string with double quotes', () => {
         'INSERT INTO "Post" ("title") VALUES ($1) RETURNING "Post"."id"',
     );
 });
+
+it('show duration with update postgres', () => {
+    let query = '';
+    const log = createPrismaQueryEventHandler({
+        logger: (q: string) => (query = q),
+        unescape: true,
+        format: false,
+        queryDuration: true,
+    });
+    const event = {
+        ...basePrismaQueryEvent,
+        query: 'UPDATE "public"."Post" SET "published" = $1, "updatedAt" = $2 WHERE "public"."Post"."id" IN ($3)',
+        params: '[true,2021-12-21 16:56:47.280795800 UTC,4]',
+        duration: 15,
+    };
+    log(event);
+    expect(query).toEqual(
+        'UPDATE "Post" SET "published" = true, "updatedAt" = "2021-12-21 16:56:47.280795800 UTC" WHERE "Post"."id" IN (4) \u001B[33m+15ms\u001B[0m',
+    );
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export function createPrismaQueryEventHandler(
     if (typeof logger !== 'function') {
         return Function.prototype as (event: PrismaQueryEvent) => void; // noop
     }
-    const { unescape, format } = options;
+    const { unescape, format, queryDuration } = options;
     const colorQuery = format ? false : options.colorQuery;
     const colorParameter = options.colorParameter ?? colorQuery;
 
@@ -30,6 +30,7 @@ export function createPrismaQueryEventHandler(
             date => `"${date}"`,
         );
         let query = event.query;
+        const duration = event.duration;
         const parameters = parseParameters(eventParams);
         if (unescape) {
             query = unescapeQuery(query);
@@ -61,6 +62,10 @@ export function createPrismaQueryEventHandler(
 
         if (colorQuery && colorParameter) {
             query = colorQuery + query + '\u001B[0m';
+        }
+
+        if (queryDuration) {
+            query = `${query} \u001B[33m+${duration}ms\u001B[0m`;
         }
 
         logger(query);

--- a/src/options.ts
+++ b/src/options.ts
@@ -29,6 +29,11 @@ export const defaultOptions = {
      */
 
     /**
+     * Show Query Duration, default is false
+     */
+    queryDuration: false as boolean,
+
+    /**
      * Query language, default is Standard SQL
      */
     language: undefined as 'sql' | 'n1ql' | 'db2' | 'pl/sql' | undefined,


### PR DESCRIPTION
Added queryDuration as Boolean Type option. _(Default is false.)_

color is displayed in yellow.
`SELECT * FROM A +10ms`

I added a test case and it passed.

Please confirm this PR.